### PR TITLE
add skipFiles override by default for VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,11 @@
       "name": "Run single test",
       "program": "${workspaceFolder}/${relativeFile}",
       "cwd": "${workspaceFolder}",
-      "runtimeExecutable": "${workspaceFolder}/node"
+      "runtimeExecutable": "${workspaceFolder}/node",
+      "skipFiles": [
+        // VSCode excludes node internals by default. Uncomment this to include them.
+        // "<node_internals>/**"
+      ]
     },
     // Debugging C++ files
     {


### PR DESCRIPTION
As titled. This change will enable debugging node internals by default which for core makes the most sense. Includes a comment for folks to understand how to disable that if they want the original behavior. 