### PR TITLE
Fix eslint config for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,5 @@
 {
-  "eslint.useFlatConfig": true,
   "eslint.nodePath": "./tools/eslint/node_modules",
-  "eslint.options": {
-    "overrideConfigFile": "./eslint.config.mjs"
-  },
   "eslint.format.enable": true,
   "eslint.validate": [
     "javascript"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,17 @@
 {
-  "eslint.format.enable": true,
-  "eslint.nodePath": "./tools/node_modules/eslint",
+  "eslint.useFlatConfig": true,
+  "eslint.nodePath": "./tools/eslint/node_modules",
   "eslint.options": {
-    "configFile": "./.eslintrc.js"
+    "overrideConfigFile": "./eslint.config.mjs"
   },
+  "eslint.format.enable": true,
   "eslint.validate": [
     "javascript"
   ],
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+
   // clangd config
   "clangd.arguments": [
     "-header-insertion=never" // More annoying than helpful


### PR DESCRIPTION
Fix eslint config to support autoformatting and linting in node core.

Refs: 
https://github.com/nodejs/node/pull/52780
https://eslint.org/docs/latest/integrate/nodejs-api

https://github.com/user-attachments/assets/d7d8b7e6-f7f6-45b2-982f-684f83b814f2
